### PR TITLE
Generalize and speed up the tensor! macro

### DIFF
--- a/benches/macros.rs
+++ b/benches/macros.rs
@@ -1,0 +1,35 @@
+#![feature(test)]
+
+#[macro_use]
+extern crate numeric;
+extern crate test;
+
+#[bench]
+fn tensor(bencher: &mut test::Bencher) {
+    const T: f64 = 42.0;
+    bencher.iter(|| {
+        let tensor = tensor![
+            T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T;
+            T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T;
+            T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T;
+            T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T;
+            T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T;
+            T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T;
+            T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T;
+            T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T;
+            T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T;
+            T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T;
+            T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T;
+            T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T;
+            T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T;
+            T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T;
+            T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T;
+            T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T;
+            T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T;
+            T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T;
+            T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T;
+            T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T;
+        ];
+        test::black_box(tensor);
+    });
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -47,7 +47,7 @@ macro_rules! tensor {
     ($($x:expr),*) => (
         $crate::Tensor::new(vec![$($x),*])
     );
-    ($($($x:expr),*);*) => ({
+    ($($($x:expr),*;)*) => ({
         let mut v = Vec::new();
         let mut n = 0;
         $(
@@ -56,6 +56,9 @@ macro_rules! tensor {
         )*
         $crate::Tensor::new(v).reshape(&[n, -1])
     });
+    ($($($x:expr),*);*) => (
+        tensor![$($($x),*;)*]
+    );
 }
 
 #[cfg(test)]
@@ -65,7 +68,7 @@ mod tests {
     #[test]
     fn tensor() {
         let x = Tensor::new(vec![1, 2, 3, 4, 5, 6]).reshape(&[3, 2]);
-        let y = tensor![1, 2; 3, 4; 5, 6];
-        assert!(x == y);
+        assert!(x == tensor![1, 2; 3, 4; 5, 6]);
+        assert!(x == tensor![1, 2; 3, 4; 5, 6;]);
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -42,7 +42,7 @@
 #[macro_export]
 macro_rules! tensor {
     ($elem:expr; $n:expr) => (
-        $crate::Tensor::filled(&[$n], $elem)
+        $crate::Tensor::new(vec![$elem; $n])
     );
     ($($x:expr),*) => (
         $crate::Tensor::new(vec![$($x),*])

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -42,10 +42,10 @@
 #[macro_export]
 macro_rules! tensor {
     ($elem:expr; $n:expr) => (
-        numeric::Tensor::filled(&[$n], $elem)
+        $crate::Tensor::filled(&[$n], $elem)
     );
     ($($x:expr),*) => (
-        numeric::Tensor::new(vec![$($x),*])
+        $crate::Tensor::new(vec![$($x),*])
     );
     ($($($x:expr),*);*) => ({
         let mut v = Vec::new();
@@ -54,6 +54,18 @@ macro_rules! tensor {
             n += 1;
             $(v.push($x);)*
         )*
-        numeric::Tensor::new(v).reshape(&[n, -1])
+        $crate::Tensor::new(v).reshape(&[n, -1])
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use Tensor;
+
+    #[test]
+    fn tensor() {
+        let x = Tensor::new(vec![1, 2, 3, 4, 5, 6]).reshape(&[3, 2]);
+        let y = tensor![1, 2; 3, 4; 5, 6];
+        assert!(x == y);
+    }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -41,6 +41,8 @@
 /// ```
 #[macro_export]
 macro_rules! tensor {
+    (@count) => (0);
+    (@count $head:tt $($tail:tt)*) => (1 + tensor!(@count $($tail)*));
     ($elem:expr; $n:expr) => (
         $crate::Tensor::new(vec![$elem; $n])
     );
@@ -50,15 +52,9 @@ macro_rules! tensor {
     ($($x:expr,)*) => (
         tensor![$($x),*]
     );
-    ($($($x:expr),*;)*) => ({
-        let mut v = Vec::new();
-        let mut n = 0;
-        $(
-            n += 1;
-            $(v.push($x);)*
-        )*
-        $crate::Tensor::new(v).reshape(&[n, -1])
-    });
+    ($($($x:expr),*;)*) => (
+        $crate::Tensor::new(vec![$($($x),*),*]).reshape(&[tensor!(@count $([$($x),*])*), -1])
+    );
     ($($($x:expr),*);*) => (
         tensor![$($($x),*;)*]
     );

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -47,6 +47,9 @@ macro_rules! tensor {
     ($($x:expr),*) => (
         $crate::Tensor::new(vec![$($x),*])
     );
+    ($($x:expr,)*) => (
+        tensor![$($x),*]
+    );
     ($($($x:expr),*;)*) => ({
         let mut v = Vec::new();
         let mut n = 0;
@@ -66,7 +69,14 @@ mod tests {
     use Tensor;
 
     #[test]
-    fn tensor() {
+    fn tensor_1d() {
+        let x = Tensor::new(vec![1, 2, 3, 4, 5, 6]);
+        assert!(x == tensor![1, 2, 3, 4, 5, 6]);
+        assert!(x == tensor![1, 2, 3, 4, 5, 6,]);
+    }
+
+    #[test]
+    fn tensor_2d() {
         let x = Tensor::new(vec![1, 2, 3, 4, 5, 6]).reshape(&[3, 2]);
         assert!(x == tensor![1, 2; 3, 4; 5, 6]);
         assert!(x == tensor![1, 2; 3, 4; 5, 6;]);


### PR DESCRIPTION
Hello,

The pull request contains a number of minor adjustments to the `tensor!` macro that

* make it work with a trailing semicolon,
* make it work with a trailing comma, and
* make it count rows at compile time.

Regards,
Ivan